### PR TITLE
Fix for python 3.11

### DIFF
--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -121,7 +121,7 @@ class OscInterface:
 
     def on_avatar_parameter_changed(self, callback: Callable[[AvatarParameterChange], None]):
         self.dispatcher.map(
-            f'{EndpointPrefix.avatar_parameter}',
+            f'{EndpointPrefix.avatar_parameter.value}',
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
@@ -130,7 +130,7 @@ class OscInterface:
 
     def on_avatar_parameter_changed_legacy(self, callback: Callable[[AvatarParameterChange], None]):
         self.dispatcher.map(
-            f'{EndpointPrefix.avatar_parameters_legacy}*',
+            f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(
                 address[len(EndpointPrefix.avatar_parameters_legacy):],
                 args[0],
@@ -138,10 +138,10 @@ class OscInterface:
         )
 
     def send_avatar_parameter_legacy(self, data: AvatarParameterChange):
-        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy}{data.parameter_name}', data.parameter_value)
+        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}', data.parameter_value)
 
     def set_input(self, data: Input):
-        self._send_data(f'{EndpointPrefix.input}{data.input_name.value}', data.input_value)
+        self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(self, callback: Callable[[PropCreateReceive], None]):
         self.dispatcher.map(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cvr-osc-lib"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name="kafeijao", email="kafeijao@gmail.com" },
+  { name="novavoidhowl", email="me@novavoidhowl.com" },
 ]
 description = "A small library to interface with CVR Melon Loader OSC mod API"
 readme = "README.md"


### PR DESCRIPTION
Python 3.11 changes the behavior of Enum some what, which causes issues with the f-string var interpretation.  
This merge aims to sort that out by adding in the `.value` param  
