### PR TITLE
Add option to turn off start up messages from library

### DIFF
--- a/cvr_osc_lib/__init__.py
+++ b/cvr_osc_lib/__init__.py
@@ -1,3 +1,4 @@
+"""cvr_osc_lib - A library for sending and receiving OSC messages for CVR."""
 from cvr_osc_lib.osc_interface import OscInterface
 from cvr_osc_lib.osc_messages_data import (
     AvatarChangeReceive,

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -32,20 +32,20 @@ from cvr_osc_lib.osc_messages_data import (
 
 class EndpointPrefix(str, Enum):
     """ The OSC endpoint prefixes """
-    AVATAR_CHANGE = '/avatar/change'
-    AVATAR_PARAMETER = '/avatar/parameter'
-    AVATAR_PARAMETERS_LEGACY = '/avatar/parameters/'
-    INPUT = '/input/'
-    PROP_CREATE = '/prop/create'
-    PROP_DELETE = '/prop/delete'
-    PROP_AVAILABLE = '/prop/available'
-    PROP_PARAMETER = '/prop/parameter'
-    PROP_LOCATION = '/prop/location'
-    PROP_LOCATION_SUB = '/prop/location_sub'
-    TRACKING_DEVICE_STATUS = '/tracking/device/status'
-    TRACKING_DEVICE_DATA = '/tracking/device/data'
-    TRACKING_PLAY_SPACE_DATA = '/tracking/play_space/data'
-    CONFIG_RESET = '/config/reset'
+    avatar_change = '/avatar/change'
+    avatar_parameter = '/avatar/parameter'
+    avatar_parameters_legacy = '/avatar/parameters/'
+    input = '/input/'
+    prop_create = '/prop/create'
+    prop_delete = '/prop/delete'
+    prop_available = '/prop/available'
+    prop_parameter = '/prop/parameter'
+    prop_location = '/prop/location'
+    prop_location_sub = '/prop/location_sub'
+    tracking_device_status = '/tracking/device/status'
+    tracking_device_data = '/tracking/device/data'
+    tracking_play_space_data = '/tracking/play_space/data'
+    config_reset = '/config/reset'
 
 
 # def osc_default_handler(
@@ -206,7 +206,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.AVATAR_CHANGE,
+            EndpointPrefix.avatar_change,
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
         )
 
@@ -226,7 +226,7 @@ class OscInterface:
         -------
         None
         """
-        self._send_data(EndpointPrefix.AVATAR_CHANGE, data.avatar_guid)
+        self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
 
     def on_avatar_parameter_changed(
                                self,
@@ -246,7 +246,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            f'{EndpointPrefix.AVATAR_PARAMETER.value}',
+            f'{EndpointPrefix.avatar_parameter.value}',
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
@@ -266,7 +266,7 @@ class OscInterface:
         -------
         None
         """
-        self._send_data(EndpointPrefix.AVATAR_PARAMETER, data.parameter_value, data.parameter_name)
+        self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
 
     def on_avatar_parameter_changed_legacy(
                                        self,
@@ -286,9 +286,9 @@ class OscInterface:
             None
             """
         self.dispatcher.map(
-            f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}*',
+            f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(
-                address[len(EndpointPrefix.AVATAR_PARAMETERS_LEGACY):],
+                address[len(EndpointPrefix.avatar_parameters_legacy):],
                 args[0],
             )),
         )
@@ -309,7 +309,7 @@ class OscInterface:
         -------
         None
         """
-        self._send_data(f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}{data.parameter_name}',
+        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
                         data.parameter_value)
 
     def set_input(
@@ -329,7 +329,7 @@ class OscInterface:
         None
         """
 
-        self._send_data(f'{EndpointPrefix.INPUT.value}{data.input_name.value}', data.input_value)
+        self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(
                    self,
@@ -349,7 +349,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_CREATE,
+            EndpointPrefix.prop_create,
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
         )
 
@@ -370,9 +370,9 @@ class OscInterface:
         None
         """
         if data.prop_local_position is None:
-            self._send_data(EndpointPrefix.PROP_CREATE, data.prop_guid)
+            self._send_data(EndpointPrefix.prop_create, data.prop_guid)
         else:
-            self._send_data(EndpointPrefix.PROP_CREATE,
+            self._send_data(EndpointPrefix.prop_create,
                             data.prop_guid,
                             *astuple(data.prop_local_position))
 
@@ -438,7 +438,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_AVAILABLE,
+            EndpointPrefix.prop_available,
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
         )
 
@@ -460,7 +460,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_PARAMETER,
+            EndpointPrefix.prop_parameter,
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
         )
 
@@ -481,7 +481,7 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.PROP_PARAMETER,
+            EndpointPrefix.prop_parameter,
             data.prop_guid,
             data.prop_instance_id,
             data.prop_sync_name,
@@ -506,7 +506,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_LOCATION,
+            EndpointPrefix.prop_location,
             lambda address, *args: callback(PropLocation(
                 args[0],
                 args[1],
@@ -532,7 +532,7 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.PROP_LOCATION,
+            EndpointPrefix.prop_location,
             data.prop_guid,
             data.prop_instance_id,
             *astuple(data.prop_position),
@@ -557,7 +557,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_LOCATION_SUB,
+            EndpointPrefix.prop_location_sub,
             lambda address, *args: callback(PropLocationSub(
                 args[0],
                 args[1],
@@ -584,7 +584,7 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.PROP_LOCATION_SUB,
+            EndpointPrefix.prop_location_sub,
             data.prop_guid,
             data.prop_instance_id,
             data.prop_sub_sync_index,
@@ -610,7 +610,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.TRACKING_PLAY_SPACE_DATA,
+            EndpointPrefix.tracking_play_space_data,
             lambda address, *args: callback(TrackingPlaySpaceData(
                 Vector3(args[0], args[1], args[2]),
                 Vector3(args[3], args[4], args[5]),
@@ -635,7 +635,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.TRACKING_DEVICE_STATUS,
+            EndpointPrefix.tracking_device_status,
             lambda address, *args: callback(
                 TrackingDeviceStatus(args[0], TrackingDeviceType[args[1]], args[2], args[3]),
             ),
@@ -659,7 +659,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.TRACKING_DEVICE_DATA,
+            EndpointPrefix.tracking_device_data,
             lambda address, *args: callback(TrackingDeviceData(
                 TrackingDeviceType[args[0]],
                 args[1],
@@ -683,6 +683,6 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.CONFIG_RESET,
+            EndpointPrefix.config_reset,
             "null",
         )

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -45,6 +45,20 @@ class EndpointPrefix(str, Enum):
 
 
 # def osc_default_handler(address: str, *args) -> None:
+#     """
+#     Default handler for the OSC messages.
+#     note this is only used for debugging purposes, and will spam the console
+    
+#     parameters
+#     ----------
+#     address : str
+#         The OSC address
+#     args : list
+#         The OSC arguments
+#     returns
+#     -------
+#     None
+#     """
 #     args_str = ''
 #     for i, arg in enumerate(args):
 #         args_str += f'\n\targ#{i + 1}: {arg} [{type(arg).__name__}]'
@@ -78,6 +92,7 @@ class OscInterface:
         self.dispatcher: Dispatcher = Dispatcher()
 
         # noinspection PyTypeChecker
+        #uncomment the following line to enable the default handler (debugging purposes only)
         # self.dispatcher.set_default_handler(osc_default_handler)
 
         self.osc_lib_ip = osc_lib_ip

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -28,20 +28,20 @@ from cvr_osc_lib.osc_messages_data import (
 
 
 class EndpointPrefix(str, Enum):
-    avatar_change = '/avatar/change'
-    avatar_parameter = '/avatar/parameter'
-    avatar_parameters_legacy = '/avatar/parameters/'
-    input = '/input/'
-    prop_create = '/prop/create'
-    prop_delete = '/prop/delete'
-    prop_available = '/prop/available'
-    prop_parameter = '/prop/parameter'
-    prop_location = '/prop/location'
-    prop_location_sub = '/prop/location_sub'
-    tracking_device_status = '/tracking/device/status'
-    tracking_device_data = '/tracking/device/data'
-    tracking_play_space_data = '/tracking/play_space/data'
-    config_reset = '/config/reset'
+    AVATAR_CHANGE = '/avatar/change'
+    AVATAR_PARAMETER = '/avatar/parameter'
+    AVATAR_PARAMETERS_LEGACY = '/avatar/parameters/'
+    INPUT = '/input/'
+    PROP_CREATE = '/prop/create'
+    PROP_DELETE = '/prop/delete'
+    PROP_AVAILABLE = '/prop/available'
+    PROP_PARAMETER = '/prop/parameter'
+    PROP_LOCATION = '/prop/location'
+    PROP_LOCATION_SUB = '/prop/location_sub'
+    TRACKING_DEVICE_STATUS = '/tracking/device/status'
+    TRACKING_DEVICE_DATA = '/tracking/device/data'
+    TRACKING_PLAY_SPACE_DATA = '/tracking/play_space/data'
+    CONFIG_RESET = '/config/reset'
 
 
 # def osc_default_handler(address: str,
@@ -181,60 +181,60 @@ class OscInterface:
                           callback: Callable[[AvatarChangeReceive],
                           None]):
         self.dispatcher.map(
-            EndpointPrefix.avatar_change,
+            EndpointPrefix.AVATAR_CHANGE,
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
         )
 
     def send_avatar_change(self,
                            data: AvatarChangeSend):
-        self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
+        self._send_data(EndpointPrefix.AVATAR_CHANGE, data.avatar_guid)
 
     def on_avatar_parameter_changed(self,
                                     callback: Callable[[AvatarParameterChange],
                                     None]):
         self.dispatcher.map(
-            f'{EndpointPrefix.avatar_parameter.value}',
+            f'{EndpointPrefix.AVATAR_PARAMETER.value}',
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
     def send_avatar_parameter(self,
                               data: AvatarParameterChange):
-        self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
+        self._send_data(EndpointPrefix.AVATAR_PARAMETER, data.parameter_value, data.parameter_name)
 
     def on_avatar_parameter_changed_legacy(self,
                                            callback: Callable[[AvatarParameterChange],
                                            None]):
         self.dispatcher.map(
-            f'{EndpointPrefix.avatar_parameters_legacy.value}*',
+            f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}*',
             lambda address, *args: callback(AvatarParameterChange(
-                address[len(EndpointPrefix.avatar_parameters_legacy):],
+                address[len(EndpointPrefix.AVATAR_PARAMETERS_LEGACY):],
                 args[0],
             )),
         )
 
     def send_avatar_parameter_legacy(self,
                                      data: AvatarParameterChange):
-        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
+        self._send_data(f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}{data.parameter_name}',
                         data.parameter_value)
 
     def set_input(self,
                   data: Input):
-        self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
+        self._send_data(f'{EndpointPrefix.INPUT.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(self,
                         callback: Callable[[PropCreateReceive],
                         None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_create,
+            EndpointPrefix.PROP_CREATE,
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
         )
 
     def send_prop_create(self,
                          data: PropCreateSend):
         if data.prop_local_position is None:
-            self._send_data(EndpointPrefix.prop_create, data.prop_guid)
+            self._send_data(EndpointPrefix.PROP_CREATE, data.prop_guid)
         else:
-            self._send_data(EndpointPrefix.prop_create,
+            self._send_data(EndpointPrefix.PROP_CREATE,
                             data.prop_guid,
                             *astuple(data.prop_local_position))
 
@@ -242,14 +242,14 @@ class OscInterface:
                         callback: Callable[[PropDelete],
                         None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_delete,
+            EndpointPrefix.PROP_DELETE,
             lambda address, *args: callback(PropDelete(args[0], args[1])),
         )
 
     def send_prop_delete(self,
                          data: PropDelete):
         self._send_data(
-            EndpointPrefix.prop_delete,
+            EndpointPrefix.PROP_DELETE,
             data.prop_guid,
             data.prop_instance_id,
         )
@@ -258,7 +258,7 @@ class OscInterface:
                                      callback: Callable[[PropAvailability],
                                      None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_available,
+            EndpointPrefix.PROP_AVAILABLE,
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
         )
 
@@ -266,14 +266,14 @@ class OscInterface:
                                   callback: Callable[[PropParameter],
                                   None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_parameter,
+            EndpointPrefix.PROP_PARAMETER,
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
         )
 
     def send_prop_parameter(self,
                             data: PropParameter):
         self._send_data(
-            EndpointPrefix.prop_parameter,
+            EndpointPrefix.PROP_PARAMETER,
             data.prop_guid,
             data.prop_instance_id,
             data.prop_sync_name,
@@ -284,7 +284,7 @@ class OscInterface:
                                  callback: Callable[[PropLocation],
                                  None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_location,
+            EndpointPrefix.PROP_LOCATION,
             lambda address, *args: callback(PropLocation(
                 args[0],
                 args[1],
@@ -296,7 +296,7 @@ class OscInterface:
     def send_prop_location(self,
                            data: PropLocation):
         self._send_data(
-            EndpointPrefix.prop_location,
+            EndpointPrefix.PROP_LOCATION,
             data.prop_guid,
             data.prop_instance_id,
             *astuple(data.prop_position),
@@ -307,7 +307,7 @@ class OscInterface:
                                      callback: Callable[[PropLocationSub],
                                      None]):
         self.dispatcher.map(
-            EndpointPrefix.prop_location_sub,
+            EndpointPrefix.PROP_LOCATION_SUB,
             lambda address, *args: callback(PropLocationSub(
                 args[0],
                 args[1],
@@ -320,7 +320,7 @@ class OscInterface:
     def send_prop_location_sub_sync(self,
                                     data: PropLocationSub):
         self._send_data(
-            EndpointPrefix.prop_location_sub,
+            EndpointPrefix.PROP_LOCATION_SUB,
             data.prop_guid,
             data.prop_instance_id,
             data.prop_sub_sync_index,
@@ -332,7 +332,7 @@ class OscInterface:
                                             callback: Callable[[TrackingPlaySpaceData],
                                             None]):
         self.dispatcher.map(
-            EndpointPrefix.tracking_play_space_data,
+            EndpointPrefix.TRACKING_PLAY_SPACE_DATA,
             lambda address, *args: callback(TrackingPlaySpaceData(
                 Vector3(args[0], args[1], args[2]),
                 Vector3(args[3], args[4], args[5]),
@@ -343,7 +343,7 @@ class OscInterface:
                                           callback: Callable[[TrackingDeviceStatus],
                                           None]):
         self.dispatcher.map(
-            EndpointPrefix.tracking_device_status,
+            EndpointPrefix.TRACKING_DEVICE_STATUS,
             lambda address, *args: callback(
                 TrackingDeviceStatus(args[0], TrackingDeviceType[args[1]], args[2], args[3]),
             ),
@@ -353,7 +353,7 @@ class OscInterface:
                                         callback: Callable[[TrackingDeviceData],
                                         None]):
         self.dispatcher.map(
-            EndpointPrefix.tracking_device_data,
+            EndpointPrefix.TRACKING_DEVICE_DATA,
             lambda address, *args: callback(TrackingDeviceData(
                 TrackingDeviceType[args[0]],
                 args[1],
@@ -378,6 +378,6 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.config_reset,
+            EndpointPrefix.CONFIG_RESET,
             "null",
         )

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -141,10 +141,7 @@ class OscInterface:
             self._start_sender()
         self.sender.send_message(address, args)
 
-    def _print_starting_message(
-                            self,
-                            startup_message_mode: str
-    ):
+    def _print_starting_message(self, startup_message_mode: str):
         """
         Prints the starting message, if self.print_starting_messages is True
 
@@ -240,8 +237,7 @@ class OscInterface:
 
         returns : None
         """
-        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
-                        data.parameter_value)
+        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}', data.parameter_value)
 
     def set_input(self, data: Input):
         """
@@ -281,9 +277,7 @@ class OscInterface:
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.prop_create, data.prop_guid)
         else:
-            self._send_data(EndpointPrefix.prop_create,
-                            data.prop_guid,
-                            *astuple(data.prop_local_position))
+            self._send_data(EndpointPrefix.prop_create, data.prop_guid, *astuple(data.prop_local_position))
 
     def on_prop_deleted(self, callback: Callable[[PropDelete], None]):
         """

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -53,16 +53,12 @@ class EndpointPrefix(str, Enum):
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
 
-#     parameters
-#     ----------
-#     address : str
-#         The OSC address
-#     args : list
-#         The OSC arguments
+#     parameters: address : str
+#                     The OSC address
+#                 args : list
+#                     The OSC arguments
 
-#     returns
-#     -------
-#     None
+#     returns: None
 #     """
 #     args_str = ''
 #     for i, arg in enumerate(args):
@@ -83,16 +79,14 @@ class OscInterface:
         """
         The interface class should be used to communicate with the CVR OSC Mod.
 
-        Parameters
-        ----------
-        osc_lib_port : int, optional
-            Port this library should listen for messages coming from CVR
-        osc_cvr_ip : str, optional
-            Ip address this library should send the osc messages to CVR
-        osc_cvr_port : int, optional
-            Port this library should send the osc messages to CVR
-        osc_lib_ip : str, optional
-            Ip this library should listen for messages coming from CVR
+        Parameters: osc_lib_port : int, optional
+                        Port this library should listen for messages coming from CVR
+                    osc_cvr_ip : str, optional
+                        Ip address this library should send the osc messages to CVR
+                    osc_cvr_port : int, optional
+                        Port this library should send the osc messages to CVR
+                    osc_lib_ip : str, optional
+                        Ip this library should listen for messages coming from CVR
         """
 
         self.dispatcher: Dispatcher = Dispatcher()
@@ -114,18 +108,14 @@ class OscInterface:
         """
         Starts the OSC sender and receiver threads.
 
-        parameters
-        ----------
-        start_sender : bool, optional
-            Whether to start the sender thread or not
-        start_receiver : bool, optional
-            Whether to start the receiver thread or not
-        print_starting_messages : bool, optional
-            Whether to print the starting messages or not
+        parameters: start_sender : bool, optional
+                        Whether to start the sender thread or not
+                    start_receiver : bool, optional
+                        Whether to start the receiver thread or not
+                    print_starting_messages : bool, optional
+                        Whether to print the starting messages or not
 
-        returns
-        -------
-        None
+        returns : None
         """
 
         self.print_starting_messages = print_starting_messages
@@ -158,14 +148,10 @@ class OscInterface:
         """
         Prints the starting message, if self.print_starting_messages is True
 
-        parameters
-        ----------
-        startup_message_mode : str
+        parameters: startup_message_mode : str
             The mode the library is starting in. Can be either 'sender' or 'receiver'
 
-        returns
-        -------
-        None
+        returns : None
         """
         if self.print_starting_messages:
             if startup_message_mode == 'sender':
@@ -179,15 +165,11 @@ class OscInterface:
         """
         Registers a callback for the avatar change event.
 
-        parameters
-        ----------
-        callback : Callable[[AvatarChangeReceive], None]
-            The callback function to be called when the avatar change event is received.
-            The callback function should have one parameter, which is the AvatarChangeReceive object.
+        parameters: callback : Callable[[AvatarChangeReceive], None]
+                        The callback function to be called when the avatar change event is received.
+                        The callback function should have one parameter, which is the AvatarChangeReceive object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.avatar_change,
@@ -198,14 +180,10 @@ class OscInterface:
         """
         Sends an avatar change event to CVR.
 
-        parameters
-        ----------
-        data : AvatarChangeSend
-            The data to be sent to CVR.
+        parameters: data : AvatarChangeSend
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
 
@@ -213,15 +191,11 @@ class OscInterface:
         """
         Registers a callback for the avatar parameter change event.
 
-        parameters
-        ----------
-        callback : Callable[[AvatarParameterChange], None]
-            The callback function to be called when the avatar parameter change event is received.
-            The callback function should have one parameter, which is the AvatarParameterChange object.
+        parameters: callback : Callable[[AvatarParameterChange], None]
+                        The callback function to be called when the avatar parameter change event is received.
+                        The callback function should have one parameter, which is the AvatarParameterChange object.
 
-        returns
-        -------
-        None
+        returns: None
         """
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameter.value}',
@@ -232,14 +206,10 @@ class OscInterface:
         """
         Sends an avatar parameter change event to CVR.
 
-        parameters
-        ----------
-        data : AvatarParameterChange
-            The data to be sent to CVR.
+        parameters: data : AvatarParameterChange
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
 
@@ -247,16 +217,12 @@ class OscInterface:
         """
         Registers a callback for the avatar parameter change event.
 
-        parameters
-        ----------
-        callback : Callable[[AvatarParameterChange], None]
-            The callback function to be called when the avatar parameter change event is received.
-            The callback function should have one parameter, which is the AvatarParameterChange object.
+        parameters: callback : Callable[[AvatarParameterChange], None]
+                        The callback function to be called when the avatar parameter change event is received.
+                        The callback function should have one parameter, which is the AvatarParameterChange object.
 
-            returns
-            -------
-            None
-            """
+        returns : None
+        """
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(
@@ -269,14 +235,10 @@ class OscInterface:
         """
         Sends an avatar parameter change event to CVR.
 
-        parameters
-        ----------
-        data : AvatarParameterChange
-            The data to be sent to CVR.
+        parameters: data : AvatarParameterChange
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
                         data.parameter_value)
@@ -285,31 +247,22 @@ class OscInterface:
         """
         Sets an input value.
 
-        parameters
-        ----------
-        data : Input
-            The data to be sent to CVR.
+        parameters: data : Input
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
-
         self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(self, callback: Callable[[PropCreateReceive], None]):
         """
         Registers a callback for the prop create event.
 
-        parameters
-        ----------
-        callback : Callable[[PropCreateReceive], None]
-            The callback function to be called when the prop create event is received.
-            The callback function should have one parameter, which is the PropCreateReceive object.
+        parameters: callback : Callable[[PropCreateReceive], None]
+                        The callback function to be called when the prop create event is received.
+                        The callback function should have one parameter, which is the PropCreateReceive object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_create,
@@ -320,14 +273,10 @@ class OscInterface:
         """
         Sends a prop create event to CVR.
 
-        parameters
-        ----------
-        data : PropCreateSend
-            The data to be sent to CVR.
+        parameters: data : PropCreateSend
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.prop_create, data.prop_guid)
@@ -340,15 +289,11 @@ class OscInterface:
         """
         Registers a callback for the prop delete event.
 
-        parameters
-        ----------
-        callback : Callable[[PropDelete], None]
-            The callback function to be called when the prop delete event is received.
-            The callback function should have one parameter,which is the PropDelete object.
+        parameters: callback : Callable[[PropDelete], None]
+                        The callback function to be called when the prop delete event is received.
+                        The callback function should have one parameter, which is the PropDelete object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_delete,
@@ -359,14 +304,10 @@ class OscInterface:
         """
         Sends a prop delete event to CVR.
 
-        parameters
-        ----------
-        data : PropDelete
-            The data to be sent to CVR.
+        parameters: data : PropDelete
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(
             EndpointPrefix.prop_delete,
@@ -378,15 +319,11 @@ class OscInterface:
         """
         Registers a callback for the prop availability change event.
 
-        parameters
-        ----------
-        callback : Callable[[PropAvailability], None]
-            The callback function to be called when the prop availability change event is received.
-            The callback function should have one parameter, which is the PropAvailability object.
+        parameters: callback : Callable[[PropAvailability], None]
+                        The callback function to be called when the prop availability change event is received.
+                        The callback function should have one parameter, which is the PropAvailability object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_available,
@@ -397,15 +334,11 @@ class OscInterface:
         """
         Registers a callback for the prop parameter change event.
 
-        parameters
-        ----------
-        callback : Callable[[PropParameter], None]
-            The callback function to be called when the prop parameter change event is received.
-            The callback function should have one parameter, which is the PropParameter object.
+        parameters: callback : Callable[[PropParameter], None]
+                        The callback function to be called when the prop parameter change event is received.
+                        The callback function should have one parameter, which is the PropParameter object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_parameter,
@@ -416,14 +349,10 @@ class OscInterface:
         """
         Sends a prop parameter change event to CVR.
 
-        parameters
-        ----------
-        data : PropParameter
-            The data to be sent to CVR.
+        parameters: data : PropParameter
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(
             EndpointPrefix.prop_parameter,
@@ -437,15 +366,11 @@ class OscInterface:
         """
         Registers a callback for the prop location change event.
 
-        parameters
-        ----------
-        callback : Callable[[PropLocation], None]
-            The callback function to be called when the prop location change event is received.
-            The callback function should have one parameter, which is the PropLocation object.
+        parameters: callback : Callable[[PropLocation], None]
+                        The callback function to be called when the prop location change event is received.
+                        The callback function should have one parameter, which is the PropLocation object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_location,
@@ -461,14 +386,10 @@ class OscInterface:
         """
         Sends a prop location change event to CVR.
 
-        parameters
-        ----------
-        data : PropLocation
-            The data to be sent to CVR.
+        parameters: data : PropLocation
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(
             EndpointPrefix.prop_location,
@@ -482,15 +403,11 @@ class OscInterface:
         """
         Registers a callback for the prop location sub change event.
 
-        parameters
-        ----------
-        callback : Callable[[PropLocationSub], None]
-            The callback function to be called when the prop location sub change event is received.
-            The callback function should have one parameter, which is the PropLocationSub object.
+        parameters: callback : Callable[[PropLocationSub], None]
+                        The callback function to be called when the prop location sub change event is received.
+                        The callback function should have one parameter, which is the PropLocationSub object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_location_sub,
@@ -507,14 +424,10 @@ class OscInterface:
         """
         Sends a prop location sub sync event to CVR.
 
-        parameters
-        ----------
-        data : PropLocationSub
-            The data to be sent to CVR.
+        parameters: data : PropLocationSub
+                        The data to be sent to CVR.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self._send_data(
             EndpointPrefix.prop_location_sub,
@@ -529,15 +442,11 @@ class OscInterface:
         """
         Registers a callback for the tracking play space data change event.
 
-        parameters
-        ----------
-        callback : Callable[[TrackingPlaySpaceData], None]
-            The callback function to be called when the tracking play space data change event is received.
-            The callback function should have one parameter, which is the TrackingPlaySpaceData object.
+        parameters: callback : Callable[[TrackingPlaySpaceData], None]
+                        The callback function to be called when the tracking play space data change event is received.
+                        The callback function should have one parameter, which is the TrackingPlaySpaceData object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_play_space_data,
@@ -551,15 +460,11 @@ class OscInterface:
         """
         Registers a callback for the tracking device status change event.
 
-        parameters
-        ----------
-        callback : Callable[[TrackingDeviceStatus], None]
-            The callback function to be called when the tracking device status change event is received.
-            The callback function should have one parameter, which is the TrackingDeviceStatus object.
+        parameters: callback : Callable[[TrackingDeviceStatus], None]
+                        The callback function to be called when the tracking device status change event is received.
+                        The callback function should have one parameter, which is the TrackingDeviceStatus object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_device_status,
@@ -572,15 +477,11 @@ class OscInterface:
         """
         Registers a callback for the tracking device data change event.
 
-        parameters
-        ----------
-        callback : Callable[[TrackingDeviceData], None]
-            The callback function to be called when the tracking device data change event is received.
-            The callback function should have one parameter, which is the TrackingDeviceData object.
+        parameters: callback : Callable[[TrackingDeviceData], None]
+                        The callback function to be called when the tracking device data change event is received.
+                        The callback function should have one parameter, which is the TrackingDeviceData object.
 
-        returns
-        -------
-        None
+        returns : None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_device_data,
@@ -597,14 +498,10 @@ class OscInterface:
     def send_config_reset(self):
         """
         Send a message to CVR to reset the config.
-
         note: sending a parameter because python-osc doesn't support actual nulls, but it is ignored on the mod's end
-        parameters
-        ----------
-        None
-        returns
-        -------
-        None
+
+        parameters: None
+        returns : None
         """
         self._send_data(
             EndpointPrefix.config_reset,

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -108,19 +108,19 @@ class OscInterface:
             self._start_sender()
 
         if self.receiver is None and start_receiver:
-            self.receiver = BlockingOSCUDPServer((self.osc_lib_ip, self.osc_lib_port), self.dispatcher)
+            self.receiver = BlockingOSCUDPServer((self.osc_lib_ip, self.osc_lib_port),
+                                                 self.dispatcher)
             self._print_starting_message('receiver')
-            #print(f'Starting the OSC receiver... Will listen for messages from {self.osc_lib_ip}:{self.osc_lib_port}')
 
             # Start receiver thread
-            osc_receiver_thread = threading.Thread(name='osc_server_loop', target=lambda: self.receiver.serve_forever())
+            osc_receiver_thread = threading.Thread(name='osc_server_loop',
+                                                   target=lambda: self.receiver.serve_forever())
             osc_receiver_thread.daemon = True
             osc_receiver_thread.start()
 
     def _start_sender(self):
         self.sender = udp_client.SimpleUDPClient(self.osc_cvr_ip, self.osc_cvr_port)
         self._print_starting_message('sender')
-        # print(f'Starting the OSC sender... Will send messages to {self.osc_cvr_ip}:{self.osc_cvr_port}')
 
     def _send_data(self, address: str, *args):
         if self.sender is None:

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -99,11 +99,31 @@ class OscInterface:
         self.osc_lib_port = osc_lib_port
         self.osc_cvr_ip = osc_cvr_ip
         self.osc_cvr_port = osc_cvr_port
+        self.print_starting_messages = True
 
         self.sender = None
         self.receiver = None
 
-    def start(self, *, start_sender=True, start_receiver=True):
+    def start(self, *, start_sender=True, start_receiver=True, print_starting_messages=True):
+        """
+        Starts the OSC sender and receiver threads.
+
+        parameters
+        ----------
+        start_sender : bool, optional
+            Whether to start the sender thread or not
+        start_receiver : bool, optional
+            Whether to start the receiver thread or not
+        print_starting_messages : bool, optional
+            Whether to print the starting messages or not
+
+        returns
+        -------
+        None
+        """
+
+        self.print_starting_messages = print_starting_messages
+
         if self.sender is None and start_sender:
             self._start_sender()
 
@@ -127,23 +147,27 @@ class OscInterface:
             self._start_sender()
         self.sender.send_message(address, args)
 
+
     def _print_starting_message(self, startup_message_mode: str):
         """
-        Prints the starting message.
+        Prints the starting message, if self.print_starting_messages is True
+
         parameters
         ----------
-        message_mode : str
-            The message mode. Either 'sender' or 'receiver'
+        startup_message_mode : str
+            The mode the library is starting in. Can be either 'sender' or 'receiver'
+
         returns
         -------
         None
         """
-        if startup_message_mode == 'sender':
-            print(f'Starting the OSC sender... Will send messages to\
-                    {self.osc_cvr_ip}:{self.osc_cvr_port}')
-        elif startup_message_mode == 'receiver':
-            print(f'Starting the OSC receiver... Will listen for messages from\
-                    {self.osc_lib_ip}:{self.osc_lib_port}')
+        if self.print_starting_messages:
+            if startup_message_mode == 'sender':
+                print(f'Starting the OSC sender... Will send messages to\
+                        {self.osc_cvr_ip}:{self.osc_cvr_port}')
+            elif startup_message_mode == 'receiver':
+                print(f'Starting the OSC receiver... Will listen for messages from\
+                        {self.osc_lib_ip}:{self.osc_lib_port}')
 
     def on_avatar_changed(self, callback: Callable[[AvatarChangeReceive], None]):
         self.dispatcher.map(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -250,10 +250,10 @@ class OscInterface:
             The callback function to be called when the avatar parameter change event is received.
             The callback function should have one parameter, which is the AvatarParameterChange object.
 
-            returns
-            -------
-            None
-            """
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -109,7 +109,8 @@ class OscInterface:
 
         if self.receiver is None and start_receiver:
             self.receiver = BlockingOSCUDPServer((self.osc_lib_ip, self.osc_lib_port), self.dispatcher)
-            print(f'Starting the OSC receiver... Will listen for messages from {self.osc_lib_ip}:{self.osc_lib_port}')
+            self._print_starting_message('receiver')
+            #print(f'Starting the OSC receiver... Will listen for messages from {self.osc_lib_ip}:{self.osc_lib_port}')
 
             # Start receiver thread
             osc_receiver_thread = threading.Thread(name='osc_server_loop', target=lambda: self.receiver.serve_forever())
@@ -118,12 +119,31 @@ class OscInterface:
 
     def _start_sender(self):
         self.sender = udp_client.SimpleUDPClient(self.osc_cvr_ip, self.osc_cvr_port)
-        print(f'Starting the OSC sender... Will send messages to {self.osc_cvr_ip}:{self.osc_cvr_port}')
+        self._print_starting_message('sender')
+        # print(f'Starting the OSC sender... Will send messages to {self.osc_cvr_ip}:{self.osc_cvr_port}')
 
     def _send_data(self, address: str, *args):
         if self.sender is None:
             self._start_sender()
         self.sender.send_message(address, args)
+
+    def _print_starting_message(self, startup_message_mode: str):
+        """
+        Prints the starting message.
+        parameters
+        ----------
+        message_mode : str
+            The message mode. Either 'sender' or 'receiver'
+        returns
+        -------
+        None
+        """
+        if startup_message_mode == 'sender':
+            print(f'Starting the OSC sender... Will send messages to\
+                    {self.osc_cvr_ip}:{self.osc_cvr_port}')
+        elif startup_message_mode == 'receiver':
+            print(f'Starting the OSC receiver... Will listen for messages from\
+                    {self.osc_lib_ip}:{self.osc_lib_port}')
 
     def on_avatar_changed(self, callback: Callable[[AvatarChangeReceive], None]):
         self.dispatcher.map(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -44,7 +44,8 @@ class EndpointPrefix(str, Enum):
     config_reset = '/config/reset'
 
 
-# def osc_default_handler(address: str, *args) -> None:
+# def osc_default_handler(address: str,
+#                         *args) -> None:
 #     """
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
@@ -104,7 +105,11 @@ class OscInterface:
         self.sender = None
         self.receiver = None
 
-    def start(self, *, start_sender=True, start_receiver=True, print_starting_messages=True):
+    def start(self,
+              *,
+              start_sender=True,
+              start_receiver=True,
+              print_starting_messages=True):
         """
         Starts the OSC sender and receiver threads.
 
@@ -142,13 +147,16 @@ class OscInterface:
         self.sender = udp_client.SimpleUDPClient(self.osc_cvr_ip, self.osc_cvr_port)
         self._print_starting_message('sender')
 
-    def _send_data(self, address: str, *args):
+    def _send_data(self,
+                   address: str,
+                   *args):
         if self.sender is None:
             self._start_sender()
         self.sender.send_message(address, args)
 
 
-    def _print_starting_message(self, startup_message_mode: str):
+    def _print_starting_message(self,
+                                startup_message_mode: str):
         """
         Prints the starting message, if self.print_starting_messages is True
 
@@ -169,25 +177,33 @@ class OscInterface:
                 print(f'Starting the OSC receiver... Will listen for messages from\
                         {self.osc_lib_ip}:{self.osc_lib_port}')
 
-    def on_avatar_changed(self, callback: Callable[[AvatarChangeReceive], None]):
+    def on_avatar_changed(self,
+                          callback: Callable[[AvatarChangeReceive],
+                          None]):
         self.dispatcher.map(
             EndpointPrefix.avatar_change,
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
         )
 
-    def send_avatar_change(self, data: AvatarChangeSend):
+    def send_avatar_change(self,
+                           data: AvatarChangeSend):
         self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
 
-    def on_avatar_parameter_changed(self, callback: Callable[[AvatarParameterChange], None]):
+    def on_avatar_parameter_changed(self,
+                                    callback: Callable[[AvatarParameterChange],
+                                    None]):
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameter.value}',
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
-    def send_avatar_parameter(self, data: AvatarParameterChange):
+    def send_avatar_parameter(self,
+                              data: AvatarParameterChange):
         self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
 
-    def on_avatar_parameter_changed_legacy(self, callback: Callable[[AvatarParameterChange], None]):
+    def on_avatar_parameter_changed_legacy(self,
+                                           callback: Callable[[AvatarParameterChange],
+                                           None]):
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(
@@ -196,20 +212,25 @@ class OscInterface:
             )),
         )
 
-    def send_avatar_parameter_legacy(self, data: AvatarParameterChange):
+    def send_avatar_parameter_legacy(self,
+                                     data: AvatarParameterChange):
         self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
                         data.parameter_value)
 
-    def set_input(self, data: Input):
+    def set_input(self,
+                  data: Input):
         self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
-    def on_prop_created(self, callback: Callable[[PropCreateReceive], None]):
+    def on_prop_created(self,
+                        callback: Callable[[PropCreateReceive],
+                        None]):
         self.dispatcher.map(
             EndpointPrefix.prop_create,
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
         )
 
-    def send_prop_create(self, data: PropCreateSend):
+    def send_prop_create(self,
+                         data: PropCreateSend):
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.prop_create, data.prop_guid)
         else:
@@ -217,32 +238,40 @@ class OscInterface:
                             data.prop_guid,
                             *astuple(data.prop_local_position))
 
-    def on_prop_deleted(self, callback: Callable[[PropDelete], None]):
+    def on_prop_deleted(self,
+                        callback: Callable[[PropDelete],
+                        None]):
         self.dispatcher.map(
             EndpointPrefix.prop_delete,
             lambda address, *args: callback(PropDelete(args[0], args[1])),
         )
 
-    def send_prop_delete(self, data: PropDelete):
+    def send_prop_delete(self,
+                         data: PropDelete):
         self._send_data(
             EndpointPrefix.prop_delete,
             data.prop_guid,
             data.prop_instance_id,
         )
 
-    def on_prop_availability_changed(self, callback: Callable[[PropAvailability], None]):
+    def on_prop_availability_changed(self,
+                                     callback: Callable[[PropAvailability],
+                                     None]):
         self.dispatcher.map(
             EndpointPrefix.prop_available,
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
         )
 
-    def on_prop_parameter_changed(self, callback: Callable[[PropParameter], None]):
+    def on_prop_parameter_changed(self,
+                                  callback: Callable[[PropParameter],
+                                  None]):
         self.dispatcher.map(
             EndpointPrefix.prop_parameter,
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
         )
 
-    def send_prop_parameter(self, data: PropParameter):
+    def send_prop_parameter(self,
+                            data: PropParameter):
         self._send_data(
             EndpointPrefix.prop_parameter,
             data.prop_guid,
@@ -251,7 +280,9 @@ class OscInterface:
             data.prop_sync_value,
         )
 
-    def on_prop_location_updated(self, callback: Callable[[PropLocation], None]):
+    def on_prop_location_updated(self,
+                                 callback: Callable[[PropLocation],
+                                 None]):
         self.dispatcher.map(
             EndpointPrefix.prop_location,
             lambda address, *args: callback(PropLocation(
@@ -262,7 +293,8 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location(self, data: PropLocation):
+    def send_prop_location(self,
+                           data: PropLocation):
         self._send_data(
             EndpointPrefix.prop_location,
             data.prop_guid,
@@ -271,7 +303,9 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_prop_location_sub_updated(self, callback: Callable[[PropLocationSub], None]):
+    def on_prop_location_sub_updated(self,
+                                     callback: Callable[[PropLocationSub],
+                                     None]):
         self.dispatcher.map(
             EndpointPrefix.prop_location_sub,
             lambda address, *args: callback(PropLocationSub(
@@ -283,7 +317,8 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location_sub_sync(self, data: PropLocationSub):
+    def send_prop_location_sub_sync(self,
+                                    data: PropLocationSub):
         self._send_data(
             EndpointPrefix.prop_location_sub,
             data.prop_guid,
@@ -304,7 +339,9 @@ class OscInterface:
             )),
         )
 
-    def on_tracking_device_status_changed(self, callback: Callable[[TrackingDeviceStatus], None]):
+    def on_tracking_device_status_changed(self,
+                                          callback: Callable[[TrackingDeviceStatus],
+                                          None]):
         self.dispatcher.map(
             EndpointPrefix.tracking_device_status,
             lambda address, *args: callback(
@@ -312,7 +349,9 @@ class OscInterface:
             ),
         )
 
-    def on_tracking_device_data_updated(self, callback: Callable[[TrackingDeviceData], None]):
+    def on_tracking_device_data_updated(self,
+                                        callback: Callable[[TrackingDeviceData],
+                                        None]):
         self.dispatcher.map(
             EndpointPrefix.tracking_device_data,
             lambda address, *args: callback(TrackingDeviceData(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -48,10 +48,7 @@ class EndpointPrefix(str, Enum):
     config_reset = '/config/reset'
 
 
-# def osc_default_handler(
-#                     address: str,
-#                     *args
-# ) -> None:
+# def osc_default_handler(address: str, *args) -> None:
 #     """
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
@@ -113,13 +110,7 @@ class OscInterface:
         self.sender = None
         self.receiver = None
 
-    def start(
-          self,
-          *,
-          start_sender=True,
-          start_receiver=True,
-          print_starting_messages=True
-    ):
+    def start(self, *, start_sender=True, start_receiver=True, print_starting_messages=True):
         """
         Starts the OSC sender and receiver threads.
 
@@ -155,11 +146,7 @@ class OscInterface:
         self.sender = udp_client.SimpleUDPClient(self.osc_cvr_ip, self.osc_cvr_port)
         self._print_starting_message('sender')
 
-    def _send_data(
-               self,
-               address: str,
-               *args
-    ):
+    def _send_data(self, address: str, *args):
         if self.sender is None:
             self._start_sender()
         self.sender.send_message(address, args)
@@ -188,10 +175,7 @@ class OscInterface:
                 print(f'Starting the OSC receiver... Will listen for messages from\
                         {self.osc_lib_ip}:{self.osc_lib_port}')
 
-    def on_avatar_changed(
-                     self,
-                     callback: Callable[[AvatarChangeReceive], None]
-    ):
+    def on_avatar_changed(self, callback: Callable[[AvatarChangeReceive], None]):
         """
         Registers a callback for the avatar change event.
 
@@ -210,10 +194,7 @@ class OscInterface:
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
         )
 
-    def send_avatar_change(
-                       self,
-                       data: AvatarChangeSend
-    ):
+    def send_avatar_change(self, data: AvatarChangeSend):
         """
         Sends an avatar change event to CVR.
 
@@ -228,10 +209,7 @@ class OscInterface:
         """
         self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
 
-    def on_avatar_parameter_changed(
-                               self,
-                               callback: Callable[[AvatarParameterChange], None]
-    ):
+    def on_avatar_parameter_changed(self, callback: Callable[[AvatarParameterChange], None]):
         """
         Registers a callback for the avatar parameter change event.
 
@@ -250,10 +228,7 @@ class OscInterface:
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
-    def send_avatar_parameter(
-                           self,
-                           data: AvatarParameterChange
-    ):
+    def send_avatar_parameter(self, data: AvatarParameterChange):
         """
         Sends an avatar parameter change event to CVR.
 
@@ -268,10 +243,7 @@ class OscInterface:
         """
         self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
 
-    def on_avatar_parameter_changed_legacy(
-                                       self,
-                                       callback: Callable[[AvatarParameterChange], None]
-    ):
+    def on_avatar_parameter_changed_legacy(self, callback: Callable[[AvatarParameterChange], None]):
         """
         Registers a callback for the avatar parameter change event.
 
@@ -293,10 +265,7 @@ class OscInterface:
             )),
         )
 
-    def send_avatar_parameter_legacy(
-                                 self,
-                                 data: AvatarParameterChange
-    ):
+    def send_avatar_parameter_legacy(self, data: AvatarParameterChange):
         """
         Sends an avatar parameter change event to CVR.
 
@@ -312,10 +281,7 @@ class OscInterface:
         self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
                         data.parameter_value)
 
-    def set_input(
-              self,
-              data: Input
-    ):
+    def set_input(self, data: Input):
         """
         Sets an input value.
 
@@ -331,10 +297,7 @@ class OscInterface:
 
         self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
-    def on_prop_created(
-                   self,
-                   callback: Callable[[PropCreateReceive], None]
-    ):
+    def on_prop_created(self, callback: Callable[[PropCreateReceive], None]):
         """
         Registers a callback for the prop create event.
 
@@ -353,10 +316,7 @@ class OscInterface:
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
         )
 
-    def send_prop_create(
-                     self,
-                     data: PropCreateSend
-    ):
+    def send_prop_create(self, data: PropCreateSend):
         """
         Sends a prop create event to CVR.
 
@@ -376,10 +336,7 @@ class OscInterface:
                             data.prop_guid,
                             *astuple(data.prop_local_position))
 
-    def on_prop_deleted(
-                    self,
-                    callback: Callable[[PropDelete], None]
-    ):
+    def on_prop_deleted(self, callback: Callable[[PropDelete], None]):
         """
         Registers a callback for the prop delete event.
 
@@ -398,10 +355,7 @@ class OscInterface:
             lambda address, *args: callback(PropDelete(args[0], args[1])),
         )
 
-    def send_prop_delete(
-                     self,
-                     data: PropDelete
-    ):
+    def send_prop_delete(self, data: PropDelete):
         """
         Sends a prop delete event to CVR.
 
@@ -420,10 +374,7 @@ class OscInterface:
             data.prop_instance_id,
         )
 
-    def on_prop_availability_changed(
-                                self,
-                                callback: Callable[[PropAvailability], None]
-    ):
+    def on_prop_availability_changed(self, callback: Callable[[PropAvailability], None]):
         """
         Registers a callback for the prop availability change event.
 
@@ -442,10 +393,7 @@ class OscInterface:
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
         )
 
-    def on_prop_parameter_changed(
-                             self,
-                             callback: Callable[[PropParameter], None]
-    ):
+    def on_prop_parameter_changed(self, callback: Callable[[PropParameter], None]):
         """
         Registers a callback for the prop parameter change event.
 
@@ -464,10 +412,7 @@ class OscInterface:
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
         )
 
-    def send_prop_parameter(
-                       self,
-                       data: PropParameter
-    ):
+    def send_prop_parameter(self, data: PropParameter):
         """
         Sends a prop parameter change event to CVR.
 
@@ -488,10 +433,7 @@ class OscInterface:
             data.prop_sync_value,
         )
 
-    def on_prop_location_updated(
-                            self,
-                            callback: Callable[[PropLocation], None]
-    ):
+    def on_prop_location_updated(self, callback: Callable[[PropLocation], None]):
         """
         Registers a callback for the prop location change event.
 
@@ -515,10 +457,7 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location(
-                       self,
-                       data: PropLocation
-    ):
+    def send_prop_location(self, data: PropLocation):
         """
         Sends a prop location change event to CVR.
 
@@ -539,10 +478,7 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_prop_location_sub_updated(
-                                 self,
-                                 callback: Callable[[PropLocationSub], None]
-    ):
+    def on_prop_location_sub_updated(self, callback: Callable[[PropLocationSub], None]):
         """
         Registers a callback for the prop location sub change event.
 
@@ -567,10 +503,7 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location_sub_sync(
-                                self,
-                                data: PropLocationSub
-    ):
+    def send_prop_location_sub_sync(self, data: PropLocationSub):
         """
         Sends a prop location sub sync event to CVR.
 
@@ -592,10 +525,7 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_tracking_play_space_data_updated(
-                                        self,
-                                        callback: Callable[[TrackingPlaySpaceData], None]
-    ):
+    def on_tracking_play_space_data_updated(self, callback: Callable[[TrackingPlaySpaceData], None]):
         """
         Registers a callback for the tracking play space data change event.
 
@@ -617,10 +547,7 @@ class OscInterface:
             )),
         )
 
-    def on_tracking_device_status_changed(
-                                      self,
-                                      callback: Callable[[TrackingDeviceStatus], None]
-    ):
+    def on_tracking_device_status_changed(self, callback: Callable[[TrackingDeviceStatus], None]):
         """
         Registers a callback for the tracking device status change event.
 
@@ -641,10 +568,7 @@ class OscInterface:
             ),
         )
 
-    def on_tracking_device_data_updated(
-                                    self,
-                                    callback: Callable[[TrackingDeviceData], None]
-    ):
+    def on_tracking_device_data_updated(self, callback: Callable[[TrackingDeviceData], None]):
         """
         Registers a callback for the tracking device data change event.
 

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -1,3 +1,6 @@
+"""
+This library is used to communicate with the CVR OSC Mod.
+"""
 import threading
 from dataclasses import astuple
 from enum import Enum
@@ -28,6 +31,7 @@ from cvr_osc_lib.osc_messages_data import (
 
 
 class EndpointPrefix(str, Enum):
+    """ The OSC endpoint prefixes """
     AVATAR_CHANGE = '/avatar/change'
     AVATAR_PARAMETER = '/avatar/parameter'
     AVATAR_PARAMETERS_LEGACY = '/avatar/parameters/'
@@ -67,6 +71,7 @@ class EndpointPrefix(str, Enum):
 
 
 class OscInterface:
+    """ This class provides the interface to communicate with the CVR OSC Mod. """
     def __init__(
             self,
             osc_lib_port: int = 9001,
@@ -180,6 +185,20 @@ class OscInterface:
     def on_avatar_changed(self,
                           callback: Callable[[AvatarChangeReceive],
                           None]):
+        """
+        Registers a callback for the avatar change event.
+
+        parameters
+        ----------
+        callback : Callable[[AvatarChangeReceive], None]
+            The callback function to be called when the avatar change event is received.
+            The callback function should have one parameter, 
+              which is the AvatarChangeReceive object.
+            
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.AVATAR_CHANGE,
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
@@ -187,11 +206,37 @@ class OscInterface:
 
     def send_avatar_change(self,
                            data: AvatarChangeSend):
+        """
+        Sends an avatar change event to CVR.
+
+        parameters
+        ----------
+        data : AvatarChangeSend
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(EndpointPrefix.AVATAR_CHANGE, data.avatar_guid)
 
     def on_avatar_parameter_changed(self,
                                     callback: Callable[[AvatarParameterChange],
                                     None]):
+        """
+        Registers a callback for the avatar parameter change event.
+
+        parameters
+        ----------
+        callback : Callable[[AvatarParameterChange], None]
+            The callback function to be called when the avatar parameter change event is received.
+            The callback function should have one parameter,
+                which is the AvatarParameterChange object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             f'{EndpointPrefix.AVATAR_PARAMETER.value}',
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
@@ -199,11 +244,37 @@ class OscInterface:
 
     def send_avatar_parameter(self,
                               data: AvatarParameterChange):
+        """
+        Sends an avatar parameter change event to CVR.
+
+        parameters
+        ----------
+        data : AvatarParameterChange
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(EndpointPrefix.AVATAR_PARAMETER, data.parameter_value, data.parameter_name)
 
     def on_avatar_parameter_changed_legacy(self,
                                            callback: Callable[[AvatarParameterChange],
                                            None]):
+        """
+        Registers a callback for the avatar parameter change event.
+        
+        parameters
+        ----------
+        callback : Callable[[AvatarParameterChange], None]
+            The callback function to be called when the avatar parameter change event is received.
+            The callback function should have one parameter,
+                which is the AvatarParameterChange object.
+                
+            returns
+            -------
+            None
+            """
         self.dispatcher.map(
             f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}*',
             lambda address, *args: callback(AvatarParameterChange(
@@ -214,16 +285,55 @@ class OscInterface:
 
     def send_avatar_parameter_legacy(self,
                                      data: AvatarParameterChange):
+        """
+        Sends an avatar parameter change event to CVR.
+
+        parameters
+        ----------
+        data : AvatarParameterChange
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}{data.parameter_name}',
                         data.parameter_value)
 
     def set_input(self,
                   data: Input):
+        """
+        Sets an input value.
+
+        parameters
+        ----------
+        data : Input
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
+
         self._send_data(f'{EndpointPrefix.INPUT.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(self,
                         callback: Callable[[PropCreateReceive],
                         None]):
+        """
+        Registers a callback for the prop create event.
+
+        parameters
+        ----------
+        callback : Callable[[PropCreateReceive], None]
+            The callback function to be called when the prop create event is received.
+            The callback function should have one parameter,
+                which is the PropCreateReceive object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_CREATE,
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
@@ -231,6 +341,18 @@ class OscInterface:
 
     def send_prop_create(self,
                          data: PropCreateSend):
+        """
+        Sends a prop create event to CVR.
+
+        parameters
+        ----------
+        data : PropCreateSend
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.PROP_CREATE, data.prop_guid)
         else:
@@ -241,6 +363,20 @@ class OscInterface:
     def on_prop_deleted(self,
                         callback: Callable[[PropDelete],
                         None]):
+        """
+        Registers a callback for the prop delete event.
+
+        parameters
+        ----------
+        callback : Callable[[PropDelete], None]
+            The callback function to be called when the prop delete event is received.
+            The callback function should have one parameter,
+                which is the PropDelete object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_DELETE,
             lambda address, *args: callback(PropDelete(args[0], args[1])),
@@ -248,6 +384,18 @@ class OscInterface:
 
     def send_prop_delete(self,
                          data: PropDelete):
+        """
+        Sends a prop delete event to CVR.
+
+        parameters
+        ----------
+        data : PropDelete
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(
             EndpointPrefix.PROP_DELETE,
             data.prop_guid,
@@ -257,6 +405,20 @@ class OscInterface:
     def on_prop_availability_changed(self,
                                      callback: Callable[[PropAvailability],
                                      None]):
+        """
+        Registers a callback for the prop availability change event.
+
+        parameters
+        ----------
+        callback : Callable[[PropAvailability], None]
+            The callback function to be called when the prop availability change event is received.
+            The callback function should have one parameter,
+                which is the PropAvailability object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_AVAILABLE,
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
@@ -265,6 +427,20 @@ class OscInterface:
     def on_prop_parameter_changed(self,
                                   callback: Callable[[PropParameter],
                                   None]):
+        """
+        Registers a callback for the prop parameter change event.
+
+        parameters
+        ----------
+        callback : Callable[[PropParameter], None]
+            The callback function to be called when the prop parameter change event is received.
+            The callback function should have one parameter,
+                which is the PropParameter object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_PARAMETER,
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
@@ -272,6 +448,18 @@ class OscInterface:
 
     def send_prop_parameter(self,
                             data: PropParameter):
+        """
+        Sends a prop parameter change event to CVR.
+
+        parameters
+        ----------
+        data : PropParameter
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(
             EndpointPrefix.PROP_PARAMETER,
             data.prop_guid,
@@ -283,6 +471,20 @@ class OscInterface:
     def on_prop_location_updated(self,
                                  callback: Callable[[PropLocation],
                                  None]):
+        """
+        Registers a callback for the prop location change event.
+
+        parameters
+        ----------
+        callback : Callable[[PropLocation], None]
+            The callback function to be called when the prop location change event is received.
+            The callback function should have one parameter,
+                which is the PropLocation object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_LOCATION,
             lambda address, *args: callback(PropLocation(
@@ -295,6 +497,18 @@ class OscInterface:
 
     def send_prop_location(self,
                            data: PropLocation):
+        """
+        Sends a prop location change event to CVR.
+
+        parameters
+        ----------
+        data : PropLocation
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(
             EndpointPrefix.PROP_LOCATION,
             data.prop_guid,
@@ -306,6 +520,20 @@ class OscInterface:
     def on_prop_location_sub_updated(self,
                                      callback: Callable[[PropLocationSub],
                                      None]):
+        """
+        Registers a callback for the prop location sub change event.
+
+        parameters
+        ----------
+        callback : Callable[[PropLocationSub], None]
+            The callback function to be called when the prop location sub change event is received.
+            The callback function should have one parameter,
+                which is the PropLocationSub object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.PROP_LOCATION_SUB,
             lambda address, *args: callback(PropLocationSub(
@@ -319,6 +547,18 @@ class OscInterface:
 
     def send_prop_location_sub_sync(self,
                                     data: PropLocationSub):
+        """
+        Sends a prop location sub sync event to CVR.
+
+        parameters
+        ----------
+        data : PropLocationSub
+            The data to be sent to CVR.
+
+        returns
+        -------
+        None
+        """
         self._send_data(
             EndpointPrefix.PROP_LOCATION_SUB,
             data.prop_guid,
@@ -331,6 +571,21 @@ class OscInterface:
     def on_tracking_play_space_data_updated(self,
                                             callback: Callable[[TrackingPlaySpaceData],
                                             None]):
+        """ 
+        Registers a callback for the tracking play space data change event.
+        
+        parameters
+        ----------
+        callback : Callable[[TrackingPlaySpaceData], None]
+            The callback function to be called when the tracking,
+              play space data change event is received.
+            The callback function should have one parameter,
+              which is the TrackingPlaySpaceData object.
+                
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.TRACKING_PLAY_SPACE_DATA,
             lambda address, *args: callback(TrackingPlaySpaceData(
@@ -342,6 +597,21 @@ class OscInterface:
     def on_tracking_device_status_changed(self,
                                           callback: Callable[[TrackingDeviceStatus],
                                           None]):
+        """
+        Registers a callback for the tracking device status change event.
+        
+        parameters
+        ----------
+        callback : Callable[[TrackingDeviceStatus], None]
+            The callback function to be called when the tracking device
+              status change event is received.
+            The callback function should have one parameter,
+              which is the TrackingDeviceStatus object.
+                
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.TRACKING_DEVICE_STATUS,
             lambda address, *args: callback(
@@ -352,6 +622,21 @@ class OscInterface:
     def on_tracking_device_data_updated(self,
                                         callback: Callable[[TrackingDeviceData],
                                         None]):
+        """
+        Registers a callback for the tracking device data change event.
+
+        parameters
+        ----------
+        callback : Callable[[TrackingDeviceData], None]
+            The callback function to be called when the tracking device
+              data change event is received.
+            The callback function should have one parameter,
+              which is the TrackingDeviceData object.
+
+        returns
+        -------
+        None
+        """
         self.dispatcher.map(
             EndpointPrefix.TRACKING_DEVICE_DATA,
             lambda address, *args: callback(TrackingDeviceData(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -164,7 +164,6 @@ class OscInterface:
             self._start_sender()
         self.sender.send_message(address, args)
 
-
     def _print_starting_message(
                             self,
                             startup_message_mode: str
@@ -191,8 +190,7 @@ class OscInterface:
 
     def on_avatar_changed(
                      self,
-                     callback: Callable[[AvatarChangeReceive],
-                     None]
+                     callback: Callable[[AvatarChangeReceive], None]
     ):
         """
         Registers a callback for the avatar change event.
@@ -201,9 +199,8 @@ class OscInterface:
         ----------
         callback : Callable[[AvatarChangeReceive], None]
             The callback function to be called when the avatar change event is received.
-            The callback function should have one parameter, 
-              which is the AvatarChangeReceive object.
-            
+            The callback function should have one parameter, which is the AvatarChangeReceive object.
+
         returns
         -------
         None
@@ -233,8 +230,7 @@ class OscInterface:
 
     def on_avatar_parameter_changed(
                                self,
-                               callback: Callable[[AvatarParameterChange],
-                               None]
+                               callback: Callable[[AvatarParameterChange], None]
     ):
         """
         Registers a callback for the avatar parameter change event.
@@ -243,8 +239,7 @@ class OscInterface:
         ----------
         callback : Callable[[AvatarParameterChange], None]
             The callback function to be called when the avatar parameter change event is received.
-            The callback function should have one parameter,
-              which is the AvatarParameterChange object.
+            The callback function should have one parameter, which is the AvatarParameterChange object.
 
         returns
         -------
@@ -275,19 +270,17 @@ class OscInterface:
 
     def on_avatar_parameter_changed_legacy(
                                        self,
-                                       callback: Callable[[AvatarParameterChange],None]
+                                       callback: Callable[[AvatarParameterChange], None]
     ):
         """
         Registers a callback for the avatar parameter change event.
-        
+
         parameters
         ----------
         callback : Callable[[AvatarParameterChange], None]
-            The callback function to be called when the
-              avatar parameter change event is received.
-            The callback function should have one parameter,
-              which is the AvatarParameterChange object.
-                
+            The callback function to be called when the avatar parameter change event is received.
+            The callback function should have one parameter, which is the AvatarParameterChange object.
+
             returns
             -------
             None
@@ -348,10 +341,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropCreateReceive], None]
-            The callback function to be called when the
-              prop create event is received.
-            The callback function should have one parameter,
-              which is the PropCreateReceive object.
+            The callback function to be called when the prop create event is received.
+            The callback function should have one parameter, which is the PropCreateReceive object.
 
         returns
         -------
@@ -395,10 +386,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropDelete], None]
-            The callback function to be called when the 
-              prop delete event is received.
-            The callback function should have one parameter,
-              which is the PropDelete object.
+            The callback function to be called when the prop delete event is received.
+            The callback function should have one parameter,which is the PropDelete object.
 
         returns
         -------
@@ -441,10 +430,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropAvailability], None]
-            The callback function to be called when the prop
-              availability change event is received.
-            The callback function should have one parameter,
-              which is the PropAvailability object.
+            The callback function to be called when the prop availability change event is received.
+            The callback function should have one parameter, which is the PropAvailability object.
 
         returns
         -------
@@ -465,10 +452,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropParameter], None]
-            The callback function to be called when the prop
-              parameter change event is received.
-            The callback function should have one parameter,
-              which is the PropParameter object.
+            The callback function to be called when the prop parameter change event is received.
+            The callback function should have one parameter, which is the PropParameter object.
 
         returns
         -------
@@ -513,10 +498,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropLocation], None]
-            The callback function to be called when the prop 
-              location change event is received.
-            The callback function should have one parameter,
-              which is the PropLocation object.
+            The callback function to be called when the prop location change event is received.
+            The callback function should have one parameter, which is the PropLocation object.
 
         returns
         -------
@@ -567,8 +550,7 @@ class OscInterface:
         ----------
         callback : Callable[[PropLocationSub], None]
             The callback function to be called when the prop location sub change event is received.
-            The callback function should have one parameter,
-              which is the PropLocationSub object.
+            The callback function should have one parameter, which is the PropLocationSub object.
 
         returns
         -------
@@ -614,17 +596,15 @@ class OscInterface:
                                         self,
                                         callback: Callable[[TrackingPlaySpaceData], None]
     ):
-        """ 
+        """
         Registers a callback for the tracking play space data change event.
-        
+
         parameters
         ----------
         callback : Callable[[TrackingPlaySpaceData], None]
-            The callback function to be called when the tracking,
-              play space data change event is received.
-            The callback function should have one parameter,
-              which is the TrackingPlaySpaceData object.
-                
+            The callback function to be called when the tracking play space data change event is received.
+            The callback function should have one parameter, which is the TrackingPlaySpaceData object.
+
         returns
         -------
         None
@@ -643,15 +623,13 @@ class OscInterface:
     ):
         """
         Registers a callback for the tracking device status change event.
-        
+
         parameters
         ----------
         callback : Callable[[TrackingDeviceStatus], None]
-            The callback function to be called when the tracking device
-              status change event is received.
-            The callback function should have one parameter,
-              which is the TrackingDeviceStatus object.
-                
+            The callback function to be called when the tracking device status change event is received.
+            The callback function should have one parameter, which is the TrackingDeviceStatus object.
+
         returns
         -------
         None
@@ -673,10 +651,8 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[TrackingDeviceData], None]
-            The callback function to be called when the tracking device
-              data change event is received.
-            The callback function should have one parameter,
-              which is the TrackingDeviceData object.
+            The callback function to be called when the tracking device data change event is received.
+            The callback function should have one parameter, which is the TrackingDeviceData object.
 
         returns
         -------
@@ -697,9 +673,8 @@ class OscInterface:
     def send_config_reset(self):
         """
         Send a message to CVR to reset the config.
-        
-        note: sending a parameter because python-osc doesn't support actual nulls,
-              but it is ignored on the mod's end
+
+        note: sending a parameter because python-osc doesn't support actual nulls, but it is ignored on the mod's end
         parameters
         ----------
         None

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -326,7 +326,19 @@ class OscInterface:
         )
 
     def send_config_reset(self):
+        """
+        Send a message to CVR to reset the config.
+        
+        note: sending a parameter because python-osc doesn't support actual nulls,
+              but it is ignored on the mod's end
+        parameters
+        ----------
+        None
+        returns
+        -------
+        None
+        """
         self._send_data(
             EndpointPrefix.config_reset,
-            "null",  # sending a parameter because python-osc doesn't support actual nulls. But it is ignored on the mod
+            "null",
         )

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -231,7 +231,7 @@ class OscInterface:
         callback : Callable[[AvatarParameterChange], None]
             The callback function to be called when the avatar parameter change event is received.
             The callback function should have one parameter,
-                which is the AvatarParameterChange object.
+              which is the AvatarParameterChange object.
 
         returns
         -------
@@ -267,9 +267,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[AvatarParameterChange], None]
-            The callback function to be called when the avatar parameter change event is received.
+            The callback function to be called when the
+              avatar parameter change event is received.
             The callback function should have one parameter,
-                which is the AvatarParameterChange object.
+              which is the AvatarParameterChange object.
                 
             returns
             -------
@@ -326,9 +327,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropCreateReceive], None]
-            The callback function to be called when the prop create event is received.
+            The callback function to be called when the
+              prop create event is received.
             The callback function should have one parameter,
-                which is the PropCreateReceive object.
+              which is the PropCreateReceive object.
 
         returns
         -------
@@ -369,9 +371,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropDelete], None]
-            The callback function to be called when the prop delete event is received.
+            The callback function to be called when the 
+              prop delete event is received.
             The callback function should have one parameter,
-                which is the PropDelete object.
+              which is the PropDelete object.
 
         returns
         -------
@@ -411,9 +414,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropAvailability], None]
-            The callback function to be called when the prop availability change event is received.
+            The callback function to be called when the prop
+              availability change event is received.
             The callback function should have one parameter,
-                which is the PropAvailability object.
+              which is the PropAvailability object.
 
         returns
         -------
@@ -433,9 +437,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropParameter], None]
-            The callback function to be called when the prop parameter change event is received.
+            The callback function to be called when the prop
+              parameter change event is received.
             The callback function should have one parameter,
-                which is the PropParameter object.
+              which is the PropParameter object.
 
         returns
         -------
@@ -477,9 +482,10 @@ class OscInterface:
         parameters
         ----------
         callback : Callable[[PropLocation], None]
-            The callback function to be called when the prop location change event is received.
+            The callback function to be called when the prop 
+              location change event is received.
             The callback function should have one parameter,
-                which is the PropLocation object.
+              which is the PropLocation object.
 
         returns
         -------
@@ -528,7 +534,7 @@ class OscInterface:
         callback : Callable[[PropLocationSub], None]
             The callback function to be called when the prop location sub change event is received.
             The callback function should have one parameter,
-                which is the PropLocationSub object.
+              which is the PropLocationSub object.
 
         returns
         -------

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -53,12 +53,16 @@ class EndpointPrefix(str, Enum):
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
 
-#     parameters: address : str
-#                     The OSC address
-#                 args : list
-#                     The OSC arguments
+#     parameters
+#     ----------
+#     address : str
+#         The OSC address
+#     args : list
+#         The OSC arguments
 
-#     returns: None
+#     returns
+#     -------
+#     None
 #     """
 #     args_str = ''
 #     for i, arg in enumerate(args):
@@ -79,14 +83,16 @@ class OscInterface:
         """
         The interface class should be used to communicate with the CVR OSC Mod.
 
-        Parameters: osc_lib_port : int, optional
-                        Port this library should listen for messages coming from CVR
-                    osc_cvr_ip : str, optional
-                        Ip address this library should send the osc messages to CVR
-                    osc_cvr_port : int, optional
-                        Port this library should send the osc messages to CVR
-                    osc_lib_ip : str, optional
-                        Ip this library should listen for messages coming from CVR
+        Parameters
+        ----------
+        osc_lib_port : int, optional
+            Port this library should listen for messages coming from CVR
+        osc_cvr_ip : str, optional
+            Ip address this library should send the osc messages to CVR
+        osc_cvr_port : int, optional
+            Port this library should send the osc messages to CVR
+        osc_lib_ip : str, optional
+            Ip this library should listen for messages coming from CVR
         """
 
         self.dispatcher: Dispatcher = Dispatcher()
@@ -108,14 +114,18 @@ class OscInterface:
         """
         Starts the OSC sender and receiver threads.
 
-        parameters: start_sender : bool, optional
-                        Whether to start the sender thread or not
-                    start_receiver : bool, optional
-                        Whether to start the receiver thread or not
-                    print_starting_messages : bool, optional
-                        Whether to print the starting messages or not
+        parameters
+        ----------
+        start_sender : bool, optional
+            Whether to start the sender thread or not
+        start_receiver : bool, optional
+            Whether to start the receiver thread or not
+        print_starting_messages : bool, optional
+            Whether to print the starting messages or not
 
-        returns : None
+        returns
+        -------
+        None
         """
 
         self.print_starting_messages = print_starting_messages
@@ -145,10 +155,14 @@ class OscInterface:
         """
         Prints the starting message, if self.print_starting_messages is True
 
-        parameters: startup_message_mode : str
+        parameters
+        ----------
+        startup_message_mode : str
             The mode the library is starting in. Can be either 'sender' or 'receiver'
 
-        returns : None
+        returns
+        -------
+        None
         """
         if self.print_starting_messages:
             if startup_message_mode == 'sender':
@@ -162,11 +176,15 @@ class OscInterface:
         """
         Registers a callback for the avatar change event.
 
-        parameters: callback : Callable[[AvatarChangeReceive], None]
-                        The callback function to be called when the avatar change event is received.
-                        The callback function should have one parameter, which is the AvatarChangeReceive object.
+        parameters
+        ----------
+        callback : Callable[[AvatarChangeReceive], None]
+            The callback function to be called when the avatar change event is received.
+            The callback function should have one parameter, which is the AvatarChangeReceive object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.avatar_change,
@@ -177,10 +195,14 @@ class OscInterface:
         """
         Sends an avatar change event to CVR.
 
-        parameters: data : AvatarChangeSend
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : AvatarChangeSend
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(EndpointPrefix.avatar_change, data.avatar_guid)
 
@@ -188,11 +210,15 @@ class OscInterface:
         """
         Registers a callback for the avatar parameter change event.
 
-        parameters: callback : Callable[[AvatarParameterChange], None]
-                        The callback function to be called when the avatar parameter change event is received.
-                        The callback function should have one parameter, which is the AvatarParameterChange object.
+        parameters
+        ----------
+        callback : Callable[[AvatarParameterChange], None]
+            The callback function to be called when the avatar parameter change event is received.
+            The callback function should have one parameter, which is the AvatarParameterChange object.
 
-        returns: None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameter.value}',
@@ -203,10 +229,14 @@ class OscInterface:
         """
         Sends an avatar parameter change event to CVR.
 
-        parameters: data : AvatarParameterChange
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : AvatarParameterChange
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(EndpointPrefix.avatar_parameter, data.parameter_value, data.parameter_name)
 
@@ -214,12 +244,16 @@ class OscInterface:
         """
         Registers a callback for the avatar parameter change event.
 
-        parameters: callback : Callable[[AvatarParameterChange], None]
-                        The callback function to be called when the avatar parameter change event is received.
-                        The callback function should have one parameter, which is the AvatarParameterChange object.
+        parameters
+        ----------
+        callback : Callable[[AvatarParameterChange], None]
+            The callback function to be called when the avatar parameter change event is received.
+            The callback function should have one parameter, which is the AvatarParameterChange object.
 
-        returns : None
-        """
+            returns
+            -------
+            None
+            """
         self.dispatcher.map(
             f'{EndpointPrefix.avatar_parameters_legacy.value}*',
             lambda address, *args: callback(AvatarParameterChange(
@@ -232,10 +266,14 @@ class OscInterface:
         """
         Sends an avatar parameter change event to CVR.
 
-        parameters: data : AvatarParameterChange
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : AvatarParameterChange
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}', data.parameter_value)
 
@@ -243,22 +281,31 @@ class OscInterface:
         """
         Sets an input value.
 
-        parameters: data : Input
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : Input
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
+
         self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
 
     def on_prop_created(self, callback: Callable[[PropCreateReceive], None]):
         """
         Registers a callback for the prop create event.
 
-        parameters: callback : Callable[[PropCreateReceive], None]
-                        The callback function to be called when the prop create event is received.
-                        The callback function should have one parameter, which is the PropCreateReceive object.
+        parameters
+        ----------
+        callback : Callable[[PropCreateReceive], None]
+            The callback function to be called when the prop create event is received.
+            The callback function should have one parameter, which is the PropCreateReceive object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_create,
@@ -269,10 +316,14 @@ class OscInterface:
         """
         Sends a prop create event to CVR.
 
-        parameters: data : PropCreateSend
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : PropCreateSend
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.prop_create, data.prop_guid)
@@ -283,11 +334,15 @@ class OscInterface:
         """
         Registers a callback for the prop delete event.
 
-        parameters: callback : Callable[[PropDelete], None]
-                        The callback function to be called when the prop delete event is received.
-                        The callback function should have one parameter, which is the PropDelete object.
+        parameters
+        ----------
+        callback : Callable[[PropDelete], None]
+            The callback function to be called when the prop delete event is received.
+            The callback function should have one parameter,which is the PropDelete object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_delete,
@@ -298,10 +353,14 @@ class OscInterface:
         """
         Sends a prop delete event to CVR.
 
-        parameters: data : PropDelete
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : PropDelete
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(
             EndpointPrefix.prop_delete,
@@ -313,11 +372,15 @@ class OscInterface:
         """
         Registers a callback for the prop availability change event.
 
-        parameters: callback : Callable[[PropAvailability], None]
-                        The callback function to be called when the prop availability change event is received.
-                        The callback function should have one parameter, which is the PropAvailability object.
+        parameters
+        ----------
+        callback : Callable[[PropAvailability], None]
+            The callback function to be called when the prop availability change event is received.
+            The callback function should have one parameter, which is the PropAvailability object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_available,
@@ -328,11 +391,15 @@ class OscInterface:
         """
         Registers a callback for the prop parameter change event.
 
-        parameters: callback : Callable[[PropParameter], None]
-                        The callback function to be called when the prop parameter change event is received.
-                        The callback function should have one parameter, which is the PropParameter object.
+        parameters
+        ----------
+        callback : Callable[[PropParameter], None]
+            The callback function to be called when the prop parameter change event is received.
+            The callback function should have one parameter, which is the PropParameter object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_parameter,
@@ -343,10 +410,14 @@ class OscInterface:
         """
         Sends a prop parameter change event to CVR.
 
-        parameters: data : PropParameter
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : PropParameter
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(
             EndpointPrefix.prop_parameter,
@@ -360,11 +431,15 @@ class OscInterface:
         """
         Registers a callback for the prop location change event.
 
-        parameters: callback : Callable[[PropLocation], None]
-                        The callback function to be called when the prop location change event is received.
-                        The callback function should have one parameter, which is the PropLocation object.
+        parameters
+        ----------
+        callback : Callable[[PropLocation], None]
+            The callback function to be called when the prop location change event is received.
+            The callback function should have one parameter, which is the PropLocation object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_location,
@@ -380,10 +455,14 @@ class OscInterface:
         """
         Sends a prop location change event to CVR.
 
-        parameters: data : PropLocation
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : PropLocation
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(
             EndpointPrefix.prop_location,
@@ -397,11 +476,15 @@ class OscInterface:
         """
         Registers a callback for the prop location sub change event.
 
-        parameters: callback : Callable[[PropLocationSub], None]
-                        The callback function to be called when the prop location sub change event is received.
-                        The callback function should have one parameter, which is the PropLocationSub object.
+        parameters
+        ----------
+        callback : Callable[[PropLocationSub], None]
+            The callback function to be called when the prop location sub change event is received.
+            The callback function should have one parameter, which is the PropLocationSub object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.prop_location_sub,
@@ -418,10 +501,14 @@ class OscInterface:
         """
         Sends a prop location sub sync event to CVR.
 
-        parameters: data : PropLocationSub
-                        The data to be sent to CVR.
+        parameters
+        ----------
+        data : PropLocationSub
+            The data to be sent to CVR.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self._send_data(
             EndpointPrefix.prop_location_sub,
@@ -436,11 +523,15 @@ class OscInterface:
         """
         Registers a callback for the tracking play space data change event.
 
-        parameters: callback : Callable[[TrackingPlaySpaceData], None]
-                        The callback function to be called when the tracking play space data change event is received.
-                        The callback function should have one parameter, which is the TrackingPlaySpaceData object.
+        parameters
+        ----------
+        callback : Callable[[TrackingPlaySpaceData], None]
+            The callback function to be called when the tracking play space data change event is received.
+            The callback function should have one parameter, which is the TrackingPlaySpaceData object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_play_space_data,
@@ -454,11 +545,15 @@ class OscInterface:
         """
         Registers a callback for the tracking device status change event.
 
-        parameters: callback : Callable[[TrackingDeviceStatus], None]
-                        The callback function to be called when the tracking device status change event is received.
-                        The callback function should have one parameter, which is the TrackingDeviceStatus object.
+        parameters
+        ----------
+        callback : Callable[[TrackingDeviceStatus], None]
+            The callback function to be called when the tracking device status change event is received.
+            The callback function should have one parameter, which is the TrackingDeviceStatus object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_device_status,
@@ -471,11 +566,15 @@ class OscInterface:
         """
         Registers a callback for the tracking device data change event.
 
-        parameters: callback : Callable[[TrackingDeviceData], None]
-                        The callback function to be called when the tracking device data change event is received.
-                        The callback function should have one parameter, which is the TrackingDeviceData object.
+        parameters
+        ----------
+        callback : Callable[[TrackingDeviceData], None]
+            The callback function to be called when the tracking device data change event is received.
+            The callback function should have one parameter, which is the TrackingDeviceData object.
 
-        returns : None
+        returns
+        -------
+        None
         """
         self.dispatcher.map(
             EndpointPrefix.tracking_device_data,
@@ -492,10 +591,14 @@ class OscInterface:
     def send_config_reset(self):
         """
         Send a message to CVR to reset the config.
-        note: sending a parameter because python-osc doesn't support actual nulls, but it is ignored on the mod's end
 
-        parameters: None
-        returns : None
+        note: sending a parameter because python-osc doesn't support actual nulls, but it is ignored on the mod's end
+        parameters
+        ----------
+        None
+        returns
+        -------
+        None
         """
         self._send_data(
             EndpointPrefix.config_reset,

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -394,7 +394,7 @@ class OscInterface:
         None
         """
         self.dispatcher.map(
-            EndpointPrefix.PROP_DELETE,
+            EndpointPrefix.prop_delete,
             lambda address, *args: callback(PropDelete(args[0], args[1])),
         )
 
@@ -415,7 +415,7 @@ class OscInterface:
         None
         """
         self._send_data(
-            EndpointPrefix.PROP_DELETE,
+            EndpointPrefix.prop_delete,
             data.prop_guid,
             data.prop_instance_id,
         )

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -48,7 +48,7 @@ class EndpointPrefix(str, Enum):
 #     """
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
-    
+
 #     parameters
 #     ----------
 #     address : str
@@ -197,7 +197,8 @@ class OscInterface:
         )
 
     def send_avatar_parameter_legacy(self, data: AvatarParameterChange):
-        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}', data.parameter_value)
+        self._send_data(f'{EndpointPrefix.avatar_parameters_legacy.value}{data.parameter_name}',
+                        data.parameter_value)
 
     def set_input(self, data: Input):
         self._send_data(f'{EndpointPrefix.input.value}{data.input_name.value}', data.input_value)
@@ -212,7 +213,9 @@ class OscInterface:
         if data.prop_local_position is None:
             self._send_data(EndpointPrefix.prop_create, data.prop_guid)
         else:
-            self._send_data(EndpointPrefix.prop_create, data.prop_guid, *astuple(data.prop_local_position))
+            self._send_data(EndpointPrefix.prop_create,
+                            data.prop_guid,
+                            *astuple(data.prop_local_position))
 
     def on_prop_deleted(self, callback: Callable[[PropDelete], None]):
         self.dispatcher.map(
@@ -290,7 +293,9 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_tracking_play_space_data_updated(self, callback: Callable[[TrackingPlaySpaceData], None]):
+    def on_tracking_play_space_data_updated(self,
+                                            callback: Callable[[TrackingPlaySpaceData],
+                                            None]):
         self.dispatcher.map(
             EndpointPrefix.tracking_play_space_data,
             lambda address, *args: callback(TrackingPlaySpaceData(

--- a/cvr_osc_lib/osc_interface.py
+++ b/cvr_osc_lib/osc_interface.py
@@ -48,8 +48,10 @@ class EndpointPrefix(str, Enum):
     CONFIG_RESET = '/config/reset'
 
 
-# def osc_default_handler(address: str,
-#                         *args) -> None:
+# def osc_default_handler(
+#                     address: str,
+#                     *args
+# ) -> None:
 #     """
 #     Default handler for the OSC messages.
 #     note this is only used for debugging purposes, and will spam the console
@@ -60,6 +62,7 @@ class EndpointPrefix(str, Enum):
 #         The OSC address
 #     args : list
 #         The OSC arguments
+
 #     returns
 #     -------
 #     None
@@ -98,7 +101,7 @@ class OscInterface:
         self.dispatcher: Dispatcher = Dispatcher()
 
         # noinspection PyTypeChecker
-        #uncomment the following line to enable the default handler (debugging purposes only)
+        # uncomment the following line to enable the default handler (debugging purposes only)
         # self.dispatcher.set_default_handler(osc_default_handler)
 
         self.osc_lib_ip = osc_lib_ip
@@ -110,11 +113,13 @@ class OscInterface:
         self.sender = None
         self.receiver = None
 
-    def start(self,
-              *,
-              start_sender=True,
-              start_receiver=True,
-              print_starting_messages=True):
+    def start(
+          self,
+          *,
+          start_sender=True,
+          start_receiver=True,
+          print_starting_messages=True
+    ):
         """
         Starts the OSC sender and receiver threads.
 
@@ -138,13 +143,11 @@ class OscInterface:
             self._start_sender()
 
         if self.receiver is None and start_receiver:
-            self.receiver = BlockingOSCUDPServer((self.osc_lib_ip, self.osc_lib_port),
-                                                 self.dispatcher)
+            self.receiver = BlockingOSCUDPServer((self.osc_lib_ip, self.osc_lib_port), self.dispatcher)
             self._print_starting_message('receiver')
 
             # Start receiver thread
-            osc_receiver_thread = threading.Thread(name='osc_server_loop',
-                                                   target=lambda: self.receiver.serve_forever())
+            osc_receiver_thread = threading.Thread(name='osc_server_loop', target=lambda: self.receiver.serve_forever())
             osc_receiver_thread.daemon = True
             osc_receiver_thread.start()
 
@@ -152,16 +155,20 @@ class OscInterface:
         self.sender = udp_client.SimpleUDPClient(self.osc_cvr_ip, self.osc_cvr_port)
         self._print_starting_message('sender')
 
-    def _send_data(self,
-                   address: str,
-                   *args):
+    def _send_data(
+               self,
+               address: str,
+               *args
+    ):
         if self.sender is None:
             self._start_sender()
         self.sender.send_message(address, args)
 
 
-    def _print_starting_message(self,
-                                startup_message_mode: str):
+    def _print_starting_message(
+                            self,
+                            startup_message_mode: str
+    ):
         """
         Prints the starting message, if self.print_starting_messages is True
 
@@ -182,9 +189,11 @@ class OscInterface:
                 print(f'Starting the OSC receiver... Will listen for messages from\
                         {self.osc_lib_ip}:{self.osc_lib_port}')
 
-    def on_avatar_changed(self,
-                          callback: Callable[[AvatarChangeReceive],
-                          None]):
+    def on_avatar_changed(
+                     self,
+                     callback: Callable[[AvatarChangeReceive],
+                     None]
+    ):
         """
         Registers a callback for the avatar change event.
 
@@ -204,8 +213,10 @@ class OscInterface:
             lambda address, *args: callback(AvatarChangeReceive(args[0], args[1])),
         )
 
-    def send_avatar_change(self,
-                           data: AvatarChangeSend):
+    def send_avatar_change(
+                       self,
+                       data: AvatarChangeSend
+    ):
         """
         Sends an avatar change event to CVR.
 
@@ -220,9 +231,11 @@ class OscInterface:
         """
         self._send_data(EndpointPrefix.AVATAR_CHANGE, data.avatar_guid)
 
-    def on_avatar_parameter_changed(self,
-                                    callback: Callable[[AvatarParameterChange],
-                                    None]):
+    def on_avatar_parameter_changed(
+                               self,
+                               callback: Callable[[AvatarParameterChange],
+                               None]
+    ):
         """
         Registers a callback for the avatar parameter change event.
 
@@ -242,8 +255,10 @@ class OscInterface:
             lambda address, *args: callback(AvatarParameterChange(args[1], args[0])),
         )
 
-    def send_avatar_parameter(self,
-                              data: AvatarParameterChange):
+    def send_avatar_parameter(
+                           self,
+                           data: AvatarParameterChange
+    ):
         """
         Sends an avatar parameter change event to CVR.
 
@@ -258,9 +273,10 @@ class OscInterface:
         """
         self._send_data(EndpointPrefix.AVATAR_PARAMETER, data.parameter_value, data.parameter_name)
 
-    def on_avatar_parameter_changed_legacy(self,
-                                           callback: Callable[[AvatarParameterChange],
-                                           None]):
+    def on_avatar_parameter_changed_legacy(
+                                       self,
+                                       callback: Callable[[AvatarParameterChange],None]
+    ):
         """
         Registers a callback for the avatar parameter change event.
         
@@ -284,8 +300,10 @@ class OscInterface:
             )),
         )
 
-    def send_avatar_parameter_legacy(self,
-                                     data: AvatarParameterChange):
+    def send_avatar_parameter_legacy(
+                                 self,
+                                 data: AvatarParameterChange
+    ):
         """
         Sends an avatar parameter change event to CVR.
 
@@ -301,8 +319,10 @@ class OscInterface:
         self._send_data(f'{EndpointPrefix.AVATAR_PARAMETERS_LEGACY.value}{data.parameter_name}',
                         data.parameter_value)
 
-    def set_input(self,
-                  data: Input):
+    def set_input(
+              self,
+              data: Input
+    ):
         """
         Sets an input value.
 
@@ -318,9 +338,10 @@ class OscInterface:
 
         self._send_data(f'{EndpointPrefix.INPUT.value}{data.input_name.value}', data.input_value)
 
-    def on_prop_created(self,
-                        callback: Callable[[PropCreateReceive],
-                        None]):
+    def on_prop_created(
+                   self,
+                   callback: Callable[[PropCreateReceive], None]
+    ):
         """
         Registers a callback for the prop create event.
 
@@ -341,8 +362,10 @@ class OscInterface:
             lambda address, *args: callback(PropCreateReceive(args[0], args[1], args[2])),
         )
 
-    def send_prop_create(self,
-                         data: PropCreateSend):
+    def send_prop_create(
+                     self,
+                     data: PropCreateSend
+    ):
         """
         Sends a prop create event to CVR.
 
@@ -362,9 +385,10 @@ class OscInterface:
                             data.prop_guid,
                             *astuple(data.prop_local_position))
 
-    def on_prop_deleted(self,
-                        callback: Callable[[PropDelete],
-                        None]):
+    def on_prop_deleted(
+                    self,
+                    callback: Callable[[PropDelete], None]
+    ):
         """
         Registers a callback for the prop delete event.
 
@@ -385,8 +409,10 @@ class OscInterface:
             lambda address, *args: callback(PropDelete(args[0], args[1])),
         )
 
-    def send_prop_delete(self,
-                         data: PropDelete):
+    def send_prop_delete(
+                     self,
+                     data: PropDelete
+    ):
         """
         Sends a prop delete event to CVR.
 
@@ -405,9 +431,10 @@ class OscInterface:
             data.prop_instance_id,
         )
 
-    def on_prop_availability_changed(self,
-                                     callback: Callable[[PropAvailability],
-                                     None]):
+    def on_prop_availability_changed(
+                                self,
+                                callback: Callable[[PropAvailability], None]
+    ):
         """
         Registers a callback for the prop availability change event.
 
@@ -428,9 +455,10 @@ class OscInterface:
             lambda address, *args: callback(PropAvailability(args[0], args[1], args[2])),
         )
 
-    def on_prop_parameter_changed(self,
-                                  callback: Callable[[PropParameter],
-                                  None]):
+    def on_prop_parameter_changed(
+                             self,
+                             callback: Callable[[PropParameter], None]
+    ):
         """
         Registers a callback for the prop parameter change event.
 
@@ -451,8 +479,10 @@ class OscInterface:
             lambda address, *args: callback(PropParameter(args[0], args[1], args[2], args[3])),
         )
 
-    def send_prop_parameter(self,
-                            data: PropParameter):
+    def send_prop_parameter(
+                       self,
+                       data: PropParameter
+    ):
         """
         Sends a prop parameter change event to CVR.
 
@@ -473,9 +503,10 @@ class OscInterface:
             data.prop_sync_value,
         )
 
-    def on_prop_location_updated(self,
-                                 callback: Callable[[PropLocation],
-                                 None]):
+    def on_prop_location_updated(
+                            self,
+                            callback: Callable[[PropLocation], None]
+    ):
         """
         Registers a callback for the prop location change event.
 
@@ -501,8 +532,10 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location(self,
-                           data: PropLocation):
+    def send_prop_location(
+                       self,
+                       data: PropLocation
+    ):
         """
         Sends a prop location change event to CVR.
 
@@ -523,9 +556,10 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_prop_location_sub_updated(self,
-                                     callback: Callable[[PropLocationSub],
-                                     None]):
+    def on_prop_location_sub_updated(
+                                 self,
+                                 callback: Callable[[PropLocationSub], None]
+    ):
         """
         Registers a callback for the prop location sub change event.
 
@@ -551,8 +585,10 @@ class OscInterface:
             )),
         )
 
-    def send_prop_location_sub_sync(self,
-                                    data: PropLocationSub):
+    def send_prop_location_sub_sync(
+                                self,
+                                data: PropLocationSub
+    ):
         """
         Sends a prop location sub sync event to CVR.
 
@@ -574,9 +610,10 @@ class OscInterface:
             *astuple(data.prop_euler_rotation),
         )
 
-    def on_tracking_play_space_data_updated(self,
-                                            callback: Callable[[TrackingPlaySpaceData],
-                                            None]):
+    def on_tracking_play_space_data_updated(
+                                        self,
+                                        callback: Callable[[TrackingPlaySpaceData], None]
+    ):
         """ 
         Registers a callback for the tracking play space data change event.
         
@@ -600,9 +637,10 @@ class OscInterface:
             )),
         )
 
-    def on_tracking_device_status_changed(self,
-                                          callback: Callable[[TrackingDeviceStatus],
-                                          None]):
+    def on_tracking_device_status_changed(
+                                      self,
+                                      callback: Callable[[TrackingDeviceStatus], None]
+    ):
         """
         Registers a callback for the tracking device status change event.
         
@@ -625,9 +663,10 @@ class OscInterface:
             ),
         )
 
-    def on_tracking_device_data_updated(self,
-                                        callback: Callable[[TrackingDeviceData],
-                                        None]):
+    def on_tracking_device_data_updated(
+                                    self,
+                                    callback: Callable[[TrackingDeviceData], None]
+    ):
         """
         Registers a callback for the tracking device data change event.
 

--- a/cvr_osc_lib/osc_messages_data.py
+++ b/cvr_osc_lib/osc_messages_data.py
@@ -1,9 +1,4 @@
 """Module to define the OSC messages data classes."""
-# Disable all the UPPER_CASE violations detections in this file as
-#  there are already too many scripts using this convention,
-#  to interface with this library and it would cause too much
-#  inconvenience for others if the names were changed.
-# pylint: disable=invalid-name
 
 import dataclasses
 from dataclasses import dataclass

--- a/cvr_osc_lib/osc_messages_data.py
+++ b/cvr_osc_lib/osc_messages_data.py
@@ -12,6 +12,7 @@ from typing import Optional, Union
 
 
 class InputName(str, Enum):
+    """Class to represent the input names."""
     # AXIS
 
     horizontal = 'Horizontal',
@@ -79,6 +80,7 @@ class InputName(str, Enum):
 
 
 class TrackingDeviceType(str, Enum):
+    """Class to represent the tracking device types."""
     hmd = 'hmd'
     base_station = 'base_station'
     left_controller = 'left_controller'
@@ -88,6 +90,7 @@ class TrackingDeviceType(str, Enum):
 
 
 class TrackingViveTrackerName(str, Enum):
+    """Class to represent the vive tracker names."""
     disabled = 'vive_tracker'
     held_in_hand = 'vive_tracker_handed'
     camera = 'vive_tracker_camera'

--- a/cvr_osc_lib/osc_messages_data.py
+++ b/cvr_osc_lib/osc_messages_data.py
@@ -1,3 +1,10 @@
+"""Module to define the OSC messages data classes."""
+# Disable all the UPPER_CASE violations detections in this file as
+#  there are already too many scripts using this convention,
+#  to interface with this library and it would cause too much
+#  inconvenience for others if the names were changed.
+# pylint: disable=invalid-name
+
 import dataclasses
 from dataclasses import dataclass
 from enum import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cvr-osc-lib"
-version = "0.1.1"
+version = "0.0.7"
 authors = [
   { name="kafeijao", email="kafeijao@gmail.com" },
   { name="novavoidhowl", email="me@novavoidhowl.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cvr-osc-lib"
-version = "0.0.6"
+version = "0.1.0"
 authors = [
   { name="kafeijao", email="kafeijao@gmail.com" },
   { name="novavoidhowl", email="me@novavoidhowl.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cvr-osc-lib"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="kafeijao", email="kafeijao@gmail.com" },
   { name="novavoidhowl", email="me@novavoidhowl.com" },


### PR DESCRIPTION
This merge adds an option to enable/disable the startup messages from the library (defaults to enabled, for backward compatibly)  

Also it adds some missing docstrings and fixes some over length lines